### PR TITLE
fix(chapter02): unbreak DPO setup (model download path + trl 1.x API)

### DIFF
--- a/code/chapter02_dpo/0-download_model.py
+++ b/code/chapter02_dpo/0-download_model.py
@@ -30,9 +30,12 @@ def download_model():
 
     print(f"正在从 ModelScope 下载模型 {MODEL_ID} ...")
     print("模型约 1GB，请耐心等待。")
+    # 用 local_dir 而不是 cache_dir：cache_dir 会按 repo 路径再嵌套
+    # 一层（./Qwen2.5-0.5B-Instruct/Qwen/Qwen2___5-0___5B-Instruct/），
+    # 导致后续脚本从 LOCAL_MODEL_DIR 加载时找不到 config.json。
     model_dir = snapshot_download(
         MODEL_ID,
-        cache_dir=LOCAL_MODEL_DIR,
+        local_dir=LOCAL_MODEL_DIR,
     )
     print(f"模型下载完成，保存至：{model_dir}")
     return model_dir

--- a/code/chapter02_dpo/3-train_dpo.py
+++ b/code/chapter02_dpo/3-train_dpo.py
@@ -1,8 +1,8 @@
 import json
 import os
 from datasets import Dataset
-from trl import DPOTrainer
-from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+from trl import DPOTrainer, DPOConfig
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # 优先使用本地模型（由 0-download_model.py 下载）
 LOCAL_MODEL_DIR = "./Qwen2.5-0.5B-Instruct"
@@ -41,21 +41,21 @@ tokenizer.pad_token = tokenizer.eos_token
 # ==========================================
 # 3. 配置训练参数与 DPOTrainer
 # ==========================================
-training_args = TrainingArguments(
+training_args = DPOConfig(
     output_dir="./output/dpo_results",
     per_device_train_batch_size=2,
     learning_rate=1e-5,
     num_train_epochs=3,   # 这里可以调大以加深学习效果
     logging_steps=5,      # 打印日志的频率
     save_steps=20,        # 模型保存频率
+    beta=0.1,             # KL 惩罚系数（trl 1.x 起属于 DPOConfig）
 )
 
 trainer = DPOTrainer(
     model=model,
     args=training_args,
     train_dataset=train_dataset,
-    tokenizer=tokenizer,
-    beta=0.1,  # KL惩罚系数，控制模型偏离参考模型（Reference Model）的程度
+    processing_class=tokenizer,  # trl 1.x 将 tokenizer 重命名为 processing_class
 )
 
 # ==========================================

--- a/code/chapter02_dpo/requirements.txt
+++ b/code/chapter02_dpo/requirements.txt
@@ -1,6 +1,6 @@
 # 第2章：DPO 偏好微调实验依赖
 transformers>=4.40.0
-trl>=0.11.0
+trl>=0.16.0
 torch>=2.0.0
 datasets>=2.14.0
 accelerate>=0.20.0


### PR DESCRIPTION
## Summary

Two independent breakages in chapter 2 (DPO) prevent a fresh install from running end-to-end. Both fixed here:

1. **Model download path** — `0-download_model.py` calls `snapshot_download(..., cache_dir=LOCAL_MODEL_DIR)`, which makes ModelScope nest the files one repo-path level deeper (`./Qwen2.5-0.5B-Instruct/Qwen/Qwen2___5-0___5B-Instruct/`). The script's own existence check (`config.json` directly under `LOCAL_MODEL_DIR`) then never short-circuits, and `2-`/`3-`/`4-` scripts loading from `LOCAL_MODEL_DIR` fail with:

   ```
   ValueError: Unrecognized model in ./Qwen2.5-0.5B-Instruct.
   Should have a `model_type` key in its config.json.
   ```

   Fix: use `local_dir=` instead of `cache_dir=`, which writes files directly under the requested path.

2. **trl 1.x API** — `3-train_dpo.py` passes `tokenizer=tokenizer` and `beta=0.1` to `DPOTrainer`. Both arguments were removed in `trl>=1.0`:

   ```
   TypeError: DPOTrainer.__init__() got an unexpected keyword argument 'tokenizer'
   ```

   `tokenizer` was renamed to `processing_class`, and `beta` moved into `DPOConfig`.

## Changes

- `0-download_model.py`: `cache_dir=` → `local_dir=` (with comment explaining why).
- `3-train_dpo.py`: switch from `TrainingArguments` to `DPOConfig`, move `beta=0.1` into the config, rename `tokenizer=` → `processing_class=`.
- `requirements.txt`: bump `trl>=0.11.0` → `trl>=0.16.0`, where `DPOConfig` + `processing_class` are stable.

## Test plan

- [x] `python 0-download_model.py` on a clean directory — files land directly in `./Qwen2.5-0.5B-Instruct/` with `config.json` at the top level.
- [x] `python 3-train_dpo.py` with `trl==1.3.0` — training starts and reports loss / rewards margins as expected.
- [ ] Verify on `trl==0.16.0` (oldest pinned version) — no breakage.