### PR TITLE
Fix total_mem typo in env-setup verification scripts

### DIFF
--- a/docs/preface/env-setup.md
+++ b/docs/preface/env-setup.md
@@ -110,7 +110,7 @@ print(f"PyTorch 版本: {torch.__version__}")
 print(f"CUDA 可用: {torch.cuda.is_available()}")
 if torch.cuda.is_available():
     print(f"GPU 名称: {torch.cuda.get_device_name(0)}")
-    print(f"GPU 显存: {torch.cuda.get_device_properties(0).total_mem / 1e9:.1f} GB")
+    print(f"GPU 显存: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
 ```
 
 ## 核心 RL 包
@@ -256,7 +256,7 @@ print(f"CUDA 版本:    {torch.version.cuda or 'CPU'}")
 if torch.cuda.is_available():
     print(f"cuDNN:        {torch.backends.cudnn.version()}")
     print(f"GPU:          {torch.cuda.get_device_name(0)}")
-    print(f"显存:         {torch.cuda.get_device_properties(0).total_mem / 1e9:.1f} GB")
+    print(f"显存:         {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
 print(f"Apple MPS:    {torch.backends.mps.is_available()}")
 print("=" * 50)
 ```


### PR DESCRIPTION
## Summary
- `torch.cuda.get_device_properties()` exposes the GPU memory field as `total_memory`, not `total_mem`.
- The two verification snippets in `docs/preface/env-setup.md` (lines 113 and 259) currently raise `AttributeError` when a CUDA GPU is present, breaking the "环境检查" experience for new readers.
- Fix: rename `total_mem` → `total_memory` in both snippets.

## Tested on
| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.3 LTS (x86_64) |
| Python | 3.12.3 |
| PyTorch | 2.11.0+cu130 |
| CUDA (PyTorch build) | 13.0 |
| GPU | NVIDIA A100-PCIE-40GB |
| NVIDIA driver | 590.48.01 |

Confirmed both fixed snippets run without error and print `GPU 显存: 42.4 GB` / `显存: 42.4 GB` on the above machine.

## Test plan
- [x] On a machine with CUDA available, paste each snippet into a Python REPL and confirm it prints the GPU memory in GB without error.
- [x] On a CPU-only machine, confirm the snippets still run (the GPU branch is skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)