### PR TITLE
fix: add trailing slash to brief-history sidebar link

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -545,7 +545,7 @@ const zhSidebar = {
       text: '前言',
       items: [
         { text: '课程导读', link: '/preface/intro' },
-        { text: '强化学习简史', link: '/preface/brief-history' },
+        { text: '强化学习简史', link: '/preface/brief-history/' },
         { text: '环境安装指南', link: '/preface/env-setup' }
       ]
     },


### PR DESCRIPTION
The 'Next Page' link on the '强化学习简史' (Brief History of RL) page incorrectly points to '课程导读' (Course Intro) instead of '环境安装指南' (Environment Setup Guide).

Root cause: brief-history uses a directory-based structure (docs/preface/brief-history/index.md). VitePress's normalize() converts its relativePath to '/preface/brief-history/' (with trailing slash), but the sidebar link '/preface/brief-history' (without trailing slash) does not match, causing findIndex to return -1 and candidates[0] to be used as the next page link.

Fix: add trailing slash to the sidebar link so normalize() produces matching paths on both sides.
<img width="1920" height="1079" alt="ScreenShot_2026-05-23_163443_420" src="https://github.com/user-attachments/assets/4d6da3f0-cd48-427f-8912-cf5368fad780" />
