### PR TITLE
fix(cartpole): add dashboard extra to swanlab dependency

### DIFF
--- a/code/chapter01_cartpole/requirements.txt
+++ b/code/chapter01_cartpole/requirements.txt
@@ -2,4 +2,4 @@
 gymnasium[classic-control]>=0.29.0
 stable-baselines3>=2.0.0
 torch>=2.0.0
-swanlab>=0.3.0
+swanlab[dashboard]>=0.3.0


### PR DESCRIPTION
SwanLab in local offline mode (mode='local') requires 'swanboard' to host the dashboard locally. Installing 'swanlab' alone does not include 'swanboard', causing an ImportError.

This patch updates the dependency to 'swanlab[dashboard]' so that the local dashboard is installed and runs out of the box.