### PR TITLE
fix(code): 恢复 SwanLab 训练时被吞掉的终端滚动日志

### DIFF
--- a/code/chapter01_cartpole/1-ppo_cartpole.py
+++ b/code/chapter01_cartpole/1-ppo_cartpole.py
@@ -20,11 +20,13 @@
 
 import argparse
 import os
+import sys
 import numpy as np
 import gymnasium as gym
-from stable_baselines3 import PPO
+from stable_baselines3 import PPO 
 from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3.common.logger import HumanOutputFormat
 from swanlab.integration.sb3 import SwanLabCallback
 import swanlab
 
@@ -51,6 +53,28 @@ class LogApproxKL(BaseCallback):
         if hasattr(logger, "name_to_value") and "train/approx_kl" in logger.name_to_value:
             value = float(logger.name_to_value["train/approx_kl"])
             swanlab.log({"train/approx_kl": value}, step=self.num_timesteps)
+
+
+class RestoreStdoutLog(BaseCallback):
+    """把 SB3 往终端打印的滚动日志表格加回来。
+
+    SwanLabCallback._init_callback() 内部会调用 self.model.set_logger(...)，
+    用一个"只写 SwanLab"的 logger 整体替换掉 SB3 默认 logger，
+    顺带删掉了负责往 stdout 打印 ep_rew_mean / fps / approx_kl 表格的
+    HumanOutputFormat（即 verbose=1 的滚动日志）。
+
+    本回调在 _init_callback 阶段执行（此时 SwanLabCallback 已替换完 logger），
+    向当前 logger 补回一个 stdout 输出端，于是终端重新滚动打印，
+    同时 SwanLab 记录不受影响。需放在 callback 列表中 SwanLabCallback 之后。
+    """
+
+    def _init_callback(self) -> None:
+        # SwanLabCallback 已把 logger 换成只含 SwanLabOutputFormat，
+        # 这里补回一个 stdout 输出端，即可恢复 verbose=1 的滚动表格。
+        self.model.logger.output_formats.append(HumanOutputFormat(sys.stdout))
+
+    def _on_step(self) -> bool:
+        return True
 
 
 def parse_args():
@@ -94,7 +118,7 @@ def main():
     )
     model.learn(
         total_timesteps=80000,
-        callback=[swanlab_cb, LogApproxKL()],
+        callback=[swanlab_cb, RestoreStdoutLog(), LogApproxKL()],
     )
 
     # 评估

--- a/code/chapter04_dqn/dqn_atari_sb3.py
+++ b/code/chapter04_dqn/dqn_atari_sb3.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,7 @@ import ale_py
 from stable_baselines3 import DQN
 from stable_baselines3.common.callbacks import BaseCallback, CallbackList, CheckpointCallback, EvalCallback
 from stable_baselines3.common.env_util import make_atari_env
+from stable_baselines3.common.logger import HumanOutputFormat
 from stable_baselines3.common.utils import set_random_seed
 from stable_baselines3.common.vec_env import VecFrameStack, VecTransposeImage
 
@@ -128,6 +130,24 @@ class SwanLabEvalCallback(BaseCallback):
             },
             step=step,
         )
+        return True
+
+
+class RestoreStdoutLog(BaseCallback):
+    """Restore SB3's rolling stdout log table that SwanLabCallback removes.
+
+    SwanLabCallback._init_callback() calls self.model.set_logger(...) and
+    replaces SB3's default logger with a SwanLab-only one, dropping the
+    HumanOutputFormat that prints the verbose=1 progress table to stdout.
+    This callback re-adds an stdout output format after that replacement,
+    so the terminal table reappears without affecting SwanLab logging.
+    Add it after SwanLabCallback in the callback list.
+    """
+
+    def _init_callback(self) -> None:
+        self.model.logger.output_formats.append(HumanOutputFormat(sys.stdout))
+
+    def _on_step(self) -> bool:
         return True
 
 
@@ -329,6 +349,7 @@ def main() -> None:
     swanlab_callback = maybe_make_swanlab_callback(args)
     if swanlab_callback is not None:
         callbacks.append(swanlab_callback)
+        callbacks.append(RestoreStdoutLog())
         callbacks.append(SwanLabEvalCallback(eval_csv_path))
 
     try:

--- a/code/chapter04_dqn/dqn_gym_sb3.py
+++ b/code/chapter04_dqn/dqn_gym_sb3.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,7 @@ from stable_baselines3 import DQN
 from stable_baselines3.common.callbacks import BaseCallback, CallbackList, CheckpointCallback, EvalCallback
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3.common.logger import HumanOutputFormat
 from stable_baselines3.common.monitor import Monitor
 
 
@@ -124,6 +126,24 @@ class SwanLabEvalCallback(BaseCallback):
             },
             step=step,
         )
+        return True
+
+
+class RestoreStdoutLog(BaseCallback):
+    """Restore SB3's rolling stdout log table that SwanLabCallback removes.
+
+    SwanLabCallback._init_callback() calls self.model.set_logger(...) and
+    replaces SB3's default logger with a SwanLab-only one, dropping the
+    HumanOutputFormat that prints the verbose=1 progress table to stdout.
+    This callback re-adds an stdout output format after that replacement,
+    so the terminal table reappears without affecting SwanLab logging.
+    Add it after SwanLabCallback in the callback list.
+    """
+
+    def _init_callback(self) -> None:
+        self.model.logger.output_formats.append(HumanOutputFormat(sys.stdout))
+
+    def _on_step(self) -> bool:
         return True
 
 
@@ -248,6 +268,7 @@ def main() -> None:
     swanlab_callback = maybe_make_swanlab_callback(args)
     if swanlab_callback is not None:
         callbacks.append(swanlab_callback)
+        callbacks.append(RestoreStdoutLog())
         callbacks.append(SwanLabEvalCallback(eval_csv_path))
 
     model.learn(


### PR DESCRIPTION
## 问题

使用 `SwanLabCallback` + `verbose=1` 训练时，终端不再滚动打印 SB3 的指标表格（`ep_rew_mean` / `approx_kl` / `exploration_rate` 等）。整个训练过程"看起来卡住"，只有结尾的评估行，数据虽然进了 SwanLab，但训练时看不到任何进度。

## 根因

`swanlab` 的 SB3 集成 `SwanLabCallback._init_callback()` 内部调用：

```python
loggers = Logger(folder=None, output_formats=[SwanLabOutputFormat(self)])
self.model.set_logger(loggers)
```

这会用"只写 SwanLab"的 logger **整体替换** SB3 的默认 logger，顺带删掉了负责往 stdout 打印进度表格的 `HumanOutputFormat`。于是 `verbose=1` 形同虚设。

## 修复

新增 `RestoreStdoutLog` 回调，在 `SwanLabCallback` 替换完 logger 之后（`_init_callback` 阶段）补回一个 stdout 输出端：

```python
class RestoreStdoutLog(BaseCallback):
    def _init_callback(self) -> None:
        self.model.logger.output_formats.append(HumanOutputFormat(sys.stdout))
    def _on_step(self) -> bool:
        return True
```

回调需排在 `SwanLabCallback` 之后加入。终端表格恢复，SwanLab 记录不受影响。该思路与现有的 `LogApproxKL` 回调（绕开同一集成的另一个坑）一致。

## 涉及文件

| 文件 | 算法 | 验证 |
| --- | --- | --- |
| `chapter01_cartpole/1-ppo_cartpole.py` | PPO | ✅ 实跑确认表格恢复 |
| `chapter04_dqn/dqn_gym_sb3.py` | DQN | ✅ 实跑 CartPole：red→green，且 `--no-swanlab` 不重复打印 |
| `chapter04_dqn/dqn_atari_sb3.py` | DQN | ⚠️ 改动与 gym 版**逐字相同**、结构一致；因需下载 ROM + 重型依赖未做真机训练验证 |

DQN 两脚本中 SwanLab 为可选依赖（`--no-swanlab` 或 import 失败时为 `None`），故回调仅在 SwanLab 启用分支加入，避免 SwanLab 不可用时与默认 logger 重复打印——已验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)