### PR TITLE
fix actor critic latex formula rendering

### DIFF
--- a/docs/chapter06_actor_critic/actor-critic.md
+++ b/docs/chapter06_actor_critic/actor-critic.md
@@ -471,7 +471,7 @@ loss = actor_loss + critic_loss  # = tensor(4.7994)
 | `reward`      | 1.0        | 环境返回的即时奖励                     |
 | `next_value`  | 2.0        | Critic 对下一状态的估计                |
 | `td_target`   | 2.98       | $r + \gamma V(s')$                     |
-| `td_error`    | 1.78       | $\delta = \text{td\_target} - V(s)$    |
+| `td_error`    | 1.78       | $\delta = \text{td\textunderscore{}target} - V(s)$ |
 | `actor_loss`  | 1.6310     | $-\log\pi \cdot \delta$（.detach 后）  |
 | `critic_loss` | 3.1684     | $\delta^2$                             |
 | `loss`        | 4.7994     | $L_{\text{actor}} + L_{\text{critic}}$ |

--- a/docs/en/chapter06_actor_critic/actor-critic.md
+++ b/docs/en/chapter06_actor_critic/actor-critic.md
@@ -475,7 +475,7 @@ Summary of key values across the entire computation chain:
 | `reward`      | 1.0        | Immediate reward returned by the environment      |
 | `next_value`  | 2.0        | Critic's estimate of the next state               |
 | `td_target`   | 2.98       | $r + \gamma V(s')$                                |
-| `td_error`    | 1.78       | $\delta = \text{td\_target} - V(s)$               |
+| `td_error`    | 1.78       | $\delta = \text{td\textunderscore{}target} - V(s)$ |
 | `actor_loss`  | 1.6310     | $-\log\pi \cdot \delta$ (after .detach)           |
 | `critic_loss` | 3.1684     | $\delta^2$                                        |
 | `loss`        | 4.7994     | $L_{\text{actor}} + L_{\text{critic}}$            |


### PR DESCRIPTION
Fix a KaTeX rendering error in the Actor-Critic value summary table by spelling the underscore in td_target as a LaTeX text underscore.\n\nVerified with npm run build and checked generated HTML for missing .katex-error.