### PR TITLE
fix: repair dpo code links

### DIFF
--- a/docs/chapter17_dpo/intro.md
+++ b/docs/chapter17_dpo/intro.md
@@ -1,6 +1,6 @@
 # 15.1 DPO 推导
 
-> 📁 **本章代码**：[0-download_model.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/0-download_model.py) · [1-generate_data.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/1-generate_data.py) · [2-test_before.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/2-test_before.py) · [3-train_dpo.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/3-train_dpo.py) · [4-test_after.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/4-test_after.py)
+> 📁 **本章代码**：[0-download_model.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/0-download_model.py) · [1-generate_data.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/1-generate_data.py) · [2-test_before.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/2-test_before.py) · [3-train_dpo.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/3-train_dpo.py) · [4-test_after.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/4-test_after.py)
 
 在上一章中，我们为传统强化学习应用设计了经典的智能体模型，例如让 CartPole 在物理规则下保持平衡。这些模型在有明确环境反馈（如游戏得分、存活时间）的情况下是有帮助的。但是，当我们面对现代自然语言处理任务时，为每个大语言模型精心设计一个能够精确给出数值奖励的"环境"实际上是极其困难的。
 
@@ -33,12 +33,12 @@
 
 ### 准备偏好数据集
 
-偏好对齐的核心在于数据。我们为你准备了一个自动生成 Mock 数据的脚本：[1-generate_data.py](../../code/chapter17_dpo/1-generate_data.py)。该脚本默认生成 100 条偏好对，每条数据包含用户提出的错误或有偏差的观点，以及两种不同的回应方式。
+偏好对齐的核心在于数据。我们为你准备了一个自动生成 Mock 数据的脚本：[1-generate_data.py](../../code/chapter02_dpo/1-generate_data.py)。该脚本默认生成 100 条偏好对，每条数据包含用户提出的错误或有偏差的观点，以及两种不同的回应方式。
 
 运行它：
 
 ```bash
-python code/chapter17_dpo/1-generate_data.py
+python code/chapter02_dpo/1-generate_data.py
 ```
 
 预期输出：
@@ -62,7 +62,7 @@ python code/chapter17_dpo/1-generate_data.py
 
 ### 测试微调前的原始输出
 
-运行配套代码：[2-test_before.py](../../code/chapter17_dpo/2-test_before.py)，用一个**不在训练集中的全新问题**来测试模型的原始行为：
+运行配套代码：[2-test_before.py](../../code/chapter02_dpo/2-test_before.py)，用一个**不在训练集中的全新问题**来测试模型的原始行为：
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -103,7 +103,7 @@ print("=" * 40)
 
 ### 运行 DPO 训练
 
-接下来，运行训练脚本：[3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py)，利用 DPO 让模型学会不盲从：
+接下来，运行训练脚本：[3-train_dpo.py](../../code/chapter02_dpo/3-train_dpo.py)，利用 DPO 让模型学会不盲从：
 
 ```python
 import json
@@ -196,7 +196,7 @@ Step  Training Loss  Rewards/Margins  Rewards/Chosen  Rewards/Rejected  Rewards/
 
 ### 测试微调后的输出
 
-现在模型已经经过偏好对齐训练。运行验证脚本：[4-test_after.py](../../code/chapter17_dpo/4-test_after.py)，用**同一个不在训练集中的问题**来测试：
+现在模型已经经过偏好对齐训练。运行验证脚本：[4-test_after.py](../../code/chapter02_dpo/4-test_after.py)，用**同一个不在训练集中的问题**来测试：
 
 ```python
 import os
@@ -242,7 +242,7 @@ print("=" * 40)
 
 ### 自定义偏好方向
 
-读者可以打开配套的 [1-generate_data.py](../../code/chapter17_dpo/1-generate_data.py) 脚本，修改其中的偏好对。例如：
+读者可以打开配套的 [1-generate_data.py](../../code/chapter02_dpo/1-generate_data.py) 脚本，修改其中的偏好对。例如：
 
 - 将 chosen 改为更直接的"毒舌式"纠正。
 - 将 rejected 改为"虽然正确但过于啰嗦"的回答。

--- a/docs/chapter17_dpo/metrics.md
+++ b/docs/chapter17_dpo/metrics.md
@@ -62,12 +62,12 @@ Margin 为正且越大，说明模型越确信"好回答比坏回答好得多"�
 <details>
 <summary><strong>如果把 <code>beta</code> 参数从 0.1 改成 1.0，Reward Margin 会怎样变化？</strong></summary>
 
-`beta` 控制模型偏离参考模型的惩罚强度——也就是 [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py) 中 `DPOConfig(beta=0.1)` 的那个参数。
+`beta` 控制模型偏离参考模型的惩罚强度——也就是 [3-train_dpo.py](../../code/chapter02_dpo/3-train_dpo.py) 中 `DPOConfig(beta=0.1)` 的那个参数。
 
 - `beta` 很大（如 1.0）：惩罚极强，模型几乎不敢改变原来的输出分布，Margin 增长极慢甚至不增长。
 - `beta` 很小（如 0.01）：模型为了拉大 Margin 而大幅偏离参考分布，可能输出人类无法理解的文本来迎合优化目标。
 
-> **动手实验**：打开 [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py)，找到 `DPOConfig` 里的 `beta` 参数，分别修改为 0.01 和 0.5，重新运行训练，观察 Margin 曲线的差异。
+> **动手实验**：打开 [3-train_dpo.py](../../code/chapter02_dpo/3-train_dpo.py)，找到 `DPOConfig` 里的 `beta` 参数，分别修改为 0.01 和 0.5，重新运行训练，观察 Margin 曲线的差异。
 
 </details>
 

--- a/docs/chapter17_dpo/principles.md
+++ b/docs/chapter17_dpo/principles.md
@@ -58,7 +58,7 @@ SFT 的训练信号只有一个方向——"模仿"，模型缺少关于"什么�
 - **输入**：(Prompt, Chosen, Rejected) 三元组。
 - **目标**：最大化好回答与坏回答的概率差。
 - **结果**：回答质量更高、更安全的对齐模型（Chat Model）。
-- **数据示例（偏好三元组）**——典型的偏好对比数据格式（与 [1-generate_data.py](../../code/chapter17_dpo/1-generate_data.py) 生成的格式一致）：
+- **数据示例（偏好三元组）**——典型的偏好对比数据格式（与 [1-generate_data.py](../../code/chapter02_dpo/1-generate_data.py) 生成的格式一致）：
   ```json
   {
     "prompt": "我今天心情很差，不想上班。",
@@ -67,7 +67,7 @@ SFT 的训练信号只有一个方向——"模仿"，模型缺少关于"什么�
   }
   ```
 
-回到我们在上一节中运行的 [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py)，代码里加载的 `preference_data.json` 正是这种格式。数据加载部分将 JSON 文件解析为 `prompt`、`chosen`、`rejected` 三个字段，分别对应符号表中的 $x$、$y_w$、$y_l$：
+回到我们在上一节中运行的 [3-train_dpo.py](../../code/chapter02_dpo/3-train_dpo.py)，代码里加载的 `preference_data.json` 正是这种格式。数据加载部分将 JSON 文件解析为 `prompt`、`chosen`、`rejected` 三个字段，分别对应符号表中的 $x$、$y_w$、$y_l$：
 
 ```python
 data_dict = {
@@ -167,7 +167,7 @@ $$ r(x, y) \propto \log \frac{\pi_{\theta}(y | x)}{\pi_{ref}(y | x)} $$
 
 基于这一洞察，DPO 的做法是：拿偏好数据（同一个问题的好回答和坏回答），直接调整模型参数，让模型提高好回答的概率、降低坏回答的概率。整个过程中只需要一个语言模型加上一份参考模型的静态备份，跳过了奖励模型训练和 PPO 的强化学习循环，将问题转化为一个对比损失函数的优化。
 
-回到 [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py) 的代码，`DPOTrainer` 在初始化时只接收一个 `model` 参数：
+回到 [3-train_dpo.py](../../code/chapter02_dpo/3-train_dpo.py) 的代码，`DPOTrainer` 在初始化时只接收一个 `model` 参数：
 
 ```python
 trainer = DPOTrainer(

--- a/docs/en/chapter17_dpo/intro.md
+++ b/docs/en/chapter17_dpo/intro.md
@@ -4,7 +4,7 @@ title: 2. DPO Preference Tuning
 
 # DPO Preference Tuning
 
-> **Chapter code**: [0-download_model.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/0-download_model.py) · [1-generate_data.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/1-generate_data.py) · [2-test_before.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/2-test_before.py) · [3-train_dpo.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/3-train_dpo.py) · [4-test_after.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter17_dpo/4-test_after.py)
+> **Chapter code**: [0-download_model.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/0-download_model.py) · [1-generate_data.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/1-generate_data.py) · [2-test_before.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/2-test_before.py) · [3-train_dpo.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/3-train_dpo.py) · [4-test_after.py](https://github.com/walkinglabs/hands-on-modern-rl/blob/main/code/chapter02_dpo/4-test_after.py)
 
 In the previous chapter, we built the classic agent loop for traditional reinforcement learning applications, for example making CartPole balance under physics rules. That setup works well when the environment provides an unambiguous scalar feedback signal (game score, survival time, and so on).
 
@@ -49,12 +49,12 @@ That "not A, but B" structure is exactly what preference data buys you.
 
 ### Step 0: Prepare the Preference Dataset
 
-The core of preference alignment is the data. We have prepared a script that automatically generates mock data: [1-generate_data.py](../../code/chapter17_dpo/1-generate_data.py). It generates 100 preference pairs by default, each containing a user's incorrect or biased claim and two different response styles.
+The core of preference alignment is the data. We have prepared a script that automatically generates mock data: [1-generate_data.py](../../../code/chapter02_dpo/1-generate_data.py). It generates 100 preference pairs by default, each containing a user's incorrect or biased claim and two different response styles.
 
 Run it:
 
 ```bash
-python code/chapter17_dpo/1-generate_data.py
+python code/chapter02_dpo/1-generate_data.py
 ```
 
 Expected output:
@@ -78,7 +78,7 @@ Note that **chosen is a response that corrects the user's misconception**, while
 
 ### Step 1: Inspect the Raw Behavior Before Training
 
-Run the companion script: [2-test_before.py](../../code/chapter17_dpo/2-test_before.py), and test the model's raw behavior with a **new question not in the training set**:
+Run the companion script: [2-test_before.py](../../../code/chapter02_dpo/2-test_before.py), and test the model's raw behavior with a **new question not in the training set**:
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -120,7 +120,7 @@ The model chose to **go along with the user's view**, agreeing with the biased c
 
 ### Step 2: Run DPO Training
 
-Next, run the training script: [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py), using DPO to teach the model not to blindly agree:
+Next, run the training script: [3-train_dpo.py](../../../code/chapter02_dpo/3-train_dpo.py), using DPO to teach the model not to blindly agree:
 
 ```python
 import json
@@ -214,7 +214,7 @@ How to read the key signals:
 
 ### Step 3: Test the Aligned Model
 
-Now the model has been preference-tuned. Run the verification script: [4-test_after.py](../../code/chapter17_dpo/4-test_after.py), using the **same out-of-training-set question**:
+Now the model has been preference-tuned. Run the verification script: [4-test_after.py](../../../code/chapter02_dpo/4-test_after.py), using the **same out-of-training-set question**:
 
 ```python
 import os
@@ -261,7 +261,7 @@ Key observation: the model no longer blindly agrees with the user. Instead, it *
 
 ### Exploration Experiment: Custom Preference Directions
 
-Readers can open the companion script [1-generate_data.py](../../code/chapter17_dpo/1-generate_data.py) and modify the preference pairs. For example:
+Readers can open the companion script [1-generate_data.py](../../../code/chapter02_dpo/1-generate_data.py) and modify the preference pairs. For example:
 
 - Change chosen to a more direct, "sharp-tongued" correction.
 - Change rejected to a "correct but overly verbose" response.

--- a/docs/en/chapter17_dpo/metrics.md
+++ b/docs/en/chapter17_dpo/metrics.md
@@ -84,7 +84,7 @@ Common causes of poor margins include: ambiguous preference pairs, extreme lengt
 <details>
 <summary><strong>What happens if we change <code>beta</code> from 0.1 to 1.0?</strong></summary>
 
-`beta` is the regularization strength controlling how far the policy is allowed to drift from the reference model. In [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py), it is set by `DPOConfig(beta=0.1)`.
+`beta` is the regularization strength controlling how far the policy is allowed to drift from the reference model. In [3-train_dpo.py](../../../code/chapter02_dpo/3-train_dpo.py), it is set by `DPOConfig(beta=0.1)`.
 
 - if `beta` is large (e.g. 1.0): the policy is heavily constrained, so margins may grow slowly or barely grow
 - if `beta` is tiny (e.g. 0.01): the policy may drift too far, sometimes learning degenerate hacks that optimize the objective but hurt response quality

--- a/docs/en/chapter17_dpo/principles.md
+++ b/docs/en/chapter17_dpo/principles.md
@@ -92,7 +92,7 @@ The objective is to make the model assign higher probability to the chosen respo
 }
 ```
 
-Returning to [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py) from the previous section, the `preference_data.json` loaded by the code is in exactly this format. The data loading part parses the JSON file into `prompt`, `chosen`, and `rejected` fields, corresponding to $x$, $y_w$, and $y_l$ in the notation:
+Returning to [3-train_dpo.py](../../../code/chapter02_dpo/3-train_dpo.py) from the previous section, the `preference_data.json` loaded by the code is in exactly this format. The data loading part parses the JSON file into `prompt`, `chosen`, and `rejected` fields, corresponding to $x$, $y_w$, and $y_l$ in the notation:
 
 ```python
 data_dict = {
@@ -191,7 +191,7 @@ That is, a response's reward score $r(x,y)$ is proportional to the log of the ra
 
 Based on this insight, DPO takes preference data (a good and a bad response to the same question) and directly adjusts model parameters to increase the probability of the good response and decrease the probability of the bad one. The entire process requires only one language model plus a static copy of the reference model, skipping the reward model training and PPO's reinforcement learning loop, reducing the problem to optimizing a contrastive loss function.
 
-Returning to the code in [3-train_dpo.py](../../code/chapter17_dpo/3-train_dpo.py), `DPOTrainer` receives only a `model` parameter at initialization:
+Returning to the code in [3-train_dpo.py](../../../code/chapter02_dpo/3-train_dpo.py), `DPOTrainer` receives only a `model` parameter at initialization:
 
 ```python
 trainer = DPOTrainer(


### PR DESCRIPTION
## Summary

- update DPO chapter code links from the non-existent code/chapter17_dpo directory to code/chapter02_dpo
- fix the matching English pages, including their deeper relative path from docs/en/chapter17_dpo
- keep the change limited to existing DPO documentation links and runnable commands

## Validation

- python3 link check: all local chapter02_dpo Python links in the touched pages resolve
- git diff --check: passed
- npm run build: passed
- npm run verify: failed at existing full-repo Prettier checks before lint/build; it reported 66 formatting warnings across unrelated files outside this PR scope