### PR TITLE
Add VeRL-Omni under Related Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,10 @@ npm run lint          # Lint VitePress theme code
 npm run verify        # Run format check, lint, build, and artifact verification
 ```
 
+## Related Frameworks
+
+- [**VeRL-Omni**](https://github.com/verl-project/verl-omni) — Easy, fast, and stable RL training for diffusion and omni-modality models; useful companion for VLM / multimodal RL practice. [[Docs](https://verl-omni.readthedocs.io/en/latest/index.html)]
+
 ## Contributing
 
 Contributions should make the course clearer, more accurate, easier to reproduce, or easier to navigate.


### PR DESCRIPTION
## Summary
- Add a **Related Frameworks** section with [VeRL-Omni](https://github.com/verl-project/verl-omni).
- Useful companion for the course’s VLM / multimodal RL chapters.

## Test plan
- [x] Entry includes docs link
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)